### PR TITLE
Feat: 승인 대기 메세지

### DIFF
--- a/src/components/Login/LoginForm.tsx
+++ b/src/components/Login/LoginForm.tsx
@@ -30,10 +30,15 @@ const LoginForm: React.FC = () => {
       return;
     }
 
-    if (getMemberStatus() === "관리자") {
+    const memberStatus = getMemberStatus();
+
+    if (memberStatus === "관리자") {
       navigate("/member-management");
-    } else {
+    } else if (memberStatus === "일반") {
       navigate("/book");
+    } else {
+      alert("승인 대기 중입니다. 다른 계정으로 다시 시도해주세요.");
+      authContext.logoutUser();
     }
   };
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -53,8 +53,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
       if (data.memberStatus === "관리자") {
         setMemberStatus("관리자");
-      } else {
+      } else if (data.memberStatus === "일반") {
         setMemberStatus("일반");
+      } else {
+        setMemberStatus("승인 대기");
       }
       return { success: true };
     } catch (error) {

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -21,7 +21,7 @@ export const removeToken = () => {
   localStorage.removeItem("accessTokenExpireTime");
 };
 
-type memberStatus = "일반" | "관리자" | null;
+type memberStatus = "일반" | "관리자" | "승인 대기";
 
 export const getMemberStatus = () => localStorage.getItem("memberStatus");
 


### PR DESCRIPTION
## Feat: 승인 대기 메세지

### PR을 한 이유 🎯

- 회원가입하고 승인 안된 유저가 로그인 되어버려서

### 이슈 번호 📎

- 

### 변경사항 🛠

- 승인 대기 상태를 구분해서 로그인 페이지로 리다이렉트 시키는 임시조치

### 특이사항 📌

- 애초에 백엔드에서 승인 대기 상태인 유저에게 토큰을 정상적으로 발급하면 안될 거 같음

### 테스트 결과 📝

- 테스트는 뭐 문제 없음